### PR TITLE
Adding an environment variable for the organization apis to work

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ baseHandler.post = function(params, callback) {
     //IamUserAccessToBilling: 'ALLOW | DENY',
     //RoleName: 'STRING_VALUE'
   };
-  var organizations = new AWS.Organizations({region: process.env.AWS_DEFAULT_REGION, credentials:credentials});
+  var organizations = new AWS.Organizations({region: process.env.REGION, credentials:credentials});
   organizations.createAccount(input, function(err, data) {
     if (err) {
       console.log(err, err.stack);

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ baseHandler.get = function(params, callback) {
     secretAccessKey: params.credentials.SecretAccessKey,
     sessionToken: params.credentials.SessionToken
   });
-  var organizations = new AWS.Organizations({region: process.env.AWS_DEFAULT_REGION, credentials:credentials});
+  var organizations = new AWS.Organizations({region: process.env.REGION, credentials:credentials});
   if (params.accountId) {
     // find detail of the given account
     var input = {

--- a/template.yaml
+++ b/template.yaml
@@ -2,6 +2,12 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Lambda Function to call the Organization API Interfaces
 
+Parameters:
+  OrganizationRegion:
+    Type: String
+    Default: "us-east-1"
+    Description: The AWS region endpoint for AWS Organizations service
+
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::Api
@@ -59,6 +65,9 @@ Resources:
             RestApiId: !Ref ApiGatewayApi
             Path: /{proxy+}
             Method: ANY
+      Environment:
+        Variables:
+          REGION: !Ref OrganizationRegion
 
 Outputs:
   APIURL:


### PR DESCRIPTION
Since the organization endpoints for all regions are same / static, we added a region variable for the lamdba function to use.

Refer, https://docs.aws.amazon.com/general/latest/gr/rande.html#ao_region

Now if the us-east-1 region is down these changes wont work, but in case of active-active configuration these changes may be useful